### PR TITLE
ARREGLA ERROR A LA HORA DEL RECUENTO ACTUAL

### DIFF
--- a/decide/voting/views.py
+++ b/decide/voting/views.py
@@ -90,12 +90,19 @@ class VotingUpdate(generics.RetrieveUpdateDestroyAPIView):
             elif not voting.end_date:
                 msg = 'Voting is not stopped'
                 st = status.HTTP_400_BAD_REQUEST
-            elif voting.tally:
-                msg = 'Voting already tallied'
-                st = status.HTTP_400_BAD_REQUEST
             else:
                 voting.tally_votes(request.auth.key)
                 msg = 'Voting tallied'
+        elif action == 'currentTally':
+            if not voting.start_date:
+                msg = 'Voting is not started'
+                st = status.HTTP_400_BAD_REQUEST
+            elif voting.end_date:
+                msg = 'Voting is stopped, you have to Tally now'
+                st = status.HTTP_400_BAD_REQUEST
+            else:
+                voting.tally_votes(request.auth.key)
+                msg = 'Voting live tallied'
         else:
             msg = 'Action not found, try with start, stop or tally'
             st = status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
Se han cambiado restricciones debido a que se podía realizar un recuento
en vivo de una votación cerrada y no comenzada.

Cambios:
- Añadido cambio en views.py de la carpeta voting.

Tareas asociadas: Tarea 01
Proyecto con tareas en
https://github.com/ivan-desing-testing/decide-single-verde-votaciones/projects/1